### PR TITLE
changed .PNG to lowercase .png for Samsung and Android galleries support 

### DIFF
--- a/android/src/main/kotlin/com/fdt/save_in_gallery/SaveInGalleryPlugin.kt
+++ b/android/src/main/kotlin/com/fdt/save_in_gallery/SaveInGalleryPlugin.kt
@@ -32,7 +32,7 @@ class SaveInGalleryPlugin(
         private const val SAVE_IMAGES_METHOD_KEY = "saveImagesKey"
         private const val SAVE_NAMED_IMAGES_METHOD_KEY = "saveNamedImagesKey"
         private const val STORAGE_PERMISSION_REQUEST = 3
-        private const val IMAGE_FILE_EXTENSION = "PNG"
+        private const val IMAGE_FILE_EXTENSION = "png"
 
         @JvmStatic
         fun registerWith(registrar: Registrar) {


### PR DESCRIPTION
A very simple fix to make images saved visible in android/samsung galleries. 

.PNG were not visible in Samsung and Android galleries. Changing to .png fixes this